### PR TITLE
Clarify Docker watcher startup behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,22 @@ docker compose up -d
 
 Le service démarre avec la commande `-watcher`.
 
+> **Note importante :**
+> Le mode `-watcher` utilisé par le compose par défaut suppose qu'un client torrent configuré soit accessible si `-noseed` n'est pas utilisé.
+> Si `qBittorrent`, `Transmission` ou `rTorrent` n'est pas encore joignable depuis le conteneur, le service peut redémarrer en boucle au lancement.
+>
+> Pour un premier test Docker sans client torrent, tu peux par exemple lancer :
+>
+> ```bash
+> docker compose run --rm unit3dup -scan /watch -noseed -noup
+> ```
+>
+> Ou modifier temporairement la commande du service en :
+>
+> ```yaml
+> command: ["-watcher", "-noseed"]
+> ```
+
 ### 5. Lancer un upload manuel
 
 Pour envoyer un fichier déjà présent dans le volume `/data` :


### PR DESCRIPTION
## Summary

This PR clarifies the Docker watcher startup behavior in the README.

## Details

The default `docker-compose.yml` starts the service with `-watcher`, which also expects a reachable torrent client unless `-noseed` is used.

Without that clarification, Docker users may see the container restart in a loop on first launch if their torrent client is not yet accessible from the container.

This adds a short note explaining:
- why that restart loop can happen
- how to do a first Docker test without a torrent client
- how to temporarily use `-watcher -noseed`
